### PR TITLE
✨ Add support for wikilink-style internal link

### DIFF
--- a/beautifulmonster/__version__.py
+++ b/beautifulmonster/__version__.py
@@ -1,5 +1,5 @@
 MAJOR = 0
 MINOR = 0
-PATCH = 3
+PATCH = 4
 
 __version__ = f'{MAJOR}.{MINOR}.{PATCH}'

--- a/beautifulmonster/__version__.py
+++ b/beautifulmonster/__version__.py
@@ -1,5 +1,5 @@
 MAJOR = 0
 MINOR = 0
-PATCH = 2
+PATCH = 3
 
 __version__ = f'{MAJOR}.{MINOR}.{PATCH}'

--- a/beautifulmonster/stew.py
+++ b/beautifulmonster/stew.py
@@ -1,8 +1,8 @@
 from bs4 import BeautifulSoup as _BeautifulSoup
 
-from markdown import markdown
-from markdown.extensions.toc import TocExtension
-from markupsafe import Markup
+from markdown import markdown as _markdown
+from markdown.extensions.toc import TocExtension as _TocExtension
+from markupsafe import Markup as _Markup
 
 
 class Pot(object):
@@ -13,15 +13,15 @@ class Pot(object):
     """
     def __init__(self, contents):
         extensions = ['extra', 'attr_list', 'nl2br', 'tables',
-                      TocExtension(baselevel=1, toc_depth=2)]
-        html_string = markdown(contents, extensions=extensions)
+                      _TocExtension(baselevel=1, toc_depth=2)]
+        html_string = _markdown(contents, extensions=extensions)
         self.soup = _BeautifulSoup(html_string, "html.parser")
 
         self.katex = False
         self.m_code()
 
     def pour(self):
-        return Markup(str(self.soup))
+        return _Markup(str(self.soup))
 
     def m_code(self):
         """

--- a/beautifulmonster/stew.py
+++ b/beautifulmonster/stew.py
@@ -2,7 +2,20 @@ from bs4 import BeautifulSoup as _BeautifulSoup
 
 from markdown import markdown as _markdown
 from markdown.extensions.toc import TocExtension as _TocExtension
+from markdown.extensions.wikilinks import (
+    WikiLinkExtension as _WikiLink,
+    WikiLinksInlineProcessor as _WikiLinksInlineProcessor)
 from markupsafe import Markup as _Markup
+
+
+class _Wiki(_WikiLink):
+    def extendMarkdown(self, md):
+        self.md = md
+        WIKILINK_RE = r'\[\[([\w0-9_ -\/]+)\]\]'
+        wikilinkPattern = _WikiLinksInlineProcessor(
+            WIKILINK_RE, self.getConfigs())
+        wikilinkPattern.md = md
+        md.inlinePatterns.register(wikilinkPattern, 'wikilink', 75)
 
 
 class Pot(object):
@@ -13,7 +26,8 @@ class Pot(object):
     """
     def __init__(self, contents):
         extensions = ['extra', 'attr_list', 'nl2br', 'tables',
-                      _TocExtension(baselevel=1, toc_depth=2)]
+                      _TocExtension(baselevel=1, toc_depth=2),
+                      _Wiki(base_url='/', end_url='/')]
         html_string = _markdown(contents, extensions=extensions)
         self.soup = _BeautifulSoup(html_string, "html.parser")
 


### PR DESCRIPTION
Convert `[[hello/1]]` to an internal link to `href=/hello/1/`.

In addition, added escaping to external library functions.