### PR TITLE
🐛 Add class to <code> generated by 3 backticks

### DIFF
--- a/beautifulmonster/__version__.py
+++ b/beautifulmonster/__version__.py
@@ -1,5 +1,5 @@
 MAJOR = 0
 MINOR = 0
-PATCH = 11
+PATCH = 12
 
 __version__ = f'{MAJOR}.{MINOR}.{PATCH}'

--- a/beautifulmonster/stew.py
+++ b/beautifulmonster/stew.py
@@ -60,8 +60,9 @@ class Pot(object):
         pres = self.soup.find_all("pre")
 
         for pre in pres:
+            codes = pre.find_all('code')
             try:
-                lang = pre.find('code')['class'][0]
+                lang = codes[0]['class'][0]
             except KeyError:
                 lang = None
 
@@ -81,6 +82,10 @@ class Pot(object):
                 lang = ''
 
             pre['class'] = f'prettyprint {lang}'
+
+            for code in codes:
+                logger.debug(f'{type(code)}')
+                code['class'] = 'in-pre'
 
     def get_doc(self):
         doc = self.soup.find('p')


### PR DESCRIPTION
Distinguish between `<code>` generated by three backticks ("```") and `<code>` generated by one backtick.

In the case of three, the `<code>` is surrounded by `<pre>`, so the class of `<code>` is set to `in-pre`.

