### PR TITLE
🐛 Fix `make_temlate`

### DIFF
--- a/beautifulmonster/__init__.py
+++ b/beautifulmonster/__init__.py
@@ -66,7 +66,7 @@ def make_app(p_obj_d_parent=_default_p_obj_config,
     make_template(config.p_obj_template)
     icons = make_icons(config.p_obj_static) if s_icons else None
 
-    fonts = make_fonts(config.font) if s_fonts else None
+    fonts = make_fonts(config.font) if s_fonts else ""
 
     app = _Flask(__name__, static_folder=None,
                  template_folder=config.p_obj_d_template)

--- a/beautifulmonster/__version__.py
+++ b/beautifulmonster/__version__.py
@@ -1,5 +1,5 @@
 MAJOR = 0
 MINOR = 1
-PATCH = 15
+PATCH = 16
 
 __version__ = f'{MAJOR}.{MINOR}.{PATCH}'

--- a/beautifulmonster/__version__.py
+++ b/beautifulmonster/__version__.py
@@ -1,5 +1,5 @@
 MAJOR = 0
 MINOR = 1
-PATCH = 14
+PATCH = 15
 
 __version__ = f'{MAJOR}.{MINOR}.{PATCH}'

--- a/beautifulmonster/puzzle.py
+++ b/beautifulmonster/puzzle.py
@@ -19,6 +19,7 @@ def make_template(p_obj_template):
     with p_obj_t.open() as f:
         data = f.read()
 
+    p_obj_template.parent.mkdir(parents=True)
     with p_obj_template.open(mode='w') as f:
         f.write(data)
 


### PR DESCRIPTION
Fixed so that `templates/template.html` is generated correctly even in the initial state.